### PR TITLE
Eliminated duplicate interface declaration

### DIFF
--- a/src/types/parser.ts
+++ b/src/types/parser.ts
@@ -50,11 +50,6 @@ interface BinaryExpressionNode extends ProgramNode {
   operator: Operator;
 }
 
-interface IdentifierNode extends ProgramNode {
-  type: "identifier";
-  value: string;
-}
-
 interface PrintStatementNode extends ProgramNode {
   type: "printStatement";
   expression: ExpressionNode;


### PR DESCRIPTION
The interface IdentifierNode was declared identically twice; I simply removed one of the two definitions.